### PR TITLE
use coordinate and anchor instead of size when drawing text

### DIFF
--- a/zen/ui/nodes/power-button.c
+++ b/zen/ui/nodes/power-button.c
@@ -72,8 +72,8 @@ zn_power_button_render(struct zigzag_node *self, cairo_t *cr)
 
   double padding = 6.;
   cairo_set_font_size(cr, 11);
-  zigzag_cairo_draw_left_aligned_text(
-      cr, output, self->frame.width, self->frame.height, padding);
+  zigzag_cairo_draw_text(cr, output, padding, self->frame.height / 2,
+      ZIGZAG_ANCHOR_LEFT, ZIGZAG_ANCHOR_CENTER);
 
   struct zn_power_button *power_button = self->user_data;
 

--- a/zigzag/include/zigzag.h
+++ b/zigzag/include/zigzag.h
@@ -4,6 +4,14 @@
 #include <wlr/render/wlr_texture.h>
 #include <wlr/util/box.h>
 
+enum zigzag_anchor {
+  ZIGZAG_ANCHOR_CENTER,
+  ZIGZAG_ANCHOR_LEFT,
+  ZIGZAG_ANCHOR_RIGHT,
+  ZIGZAG_ANCHOR_TOP,
+  ZIGZAG_ANCHOR_BOTTOM,
+};
+
 struct zigzag_node;
 
 struct zigzag_layout_impl {
@@ -75,14 +83,9 @@ struct wlr_texture *zigzag_wlr_texture_from_cairo_surface(
 void zigzag_cairo_draw_rounded_rectangle(
     cairo_t *cr, double width, double height, double radius);
 
-void zigzag_cairo_draw_centered_text(
-    cairo_t *cr, char *text, double width, double height);
 
-void zigzag_cairo_draw_left_aligned_text(
-    cairo_t *cr, char *text, double width, double height, double padding);
-
-void zigzag_cairo_draw_right_aligned_text(
-    cairo_t *cr, char *text, double width, double height, double padding);
+void zigzag_cairo_draw_text(cairo_t *cr, char *text, double x, double y,
+    enum zigzag_anchor horizontal_anchor, enum zigzag_anchor vertical_anchor);
 
 void zigzag_cairo_draw_rounded_rectangle(
     cairo_t *cr, double width, double height, double radius);

--- a/zigzag/include/zigzag.h
+++ b/zigzag/include/zigzag.h
@@ -83,7 +83,6 @@ struct wlr_texture *zigzag_wlr_texture_from_cairo_surface(
 void zigzag_cairo_draw_rounded_rectangle(
     cairo_t *cr, double width, double height, double radius);
 
-
 void zigzag_cairo_draw_text(cairo_t *cr, char *text, double x, double y,
     enum zigzag_anchor horizontal_anchor, enum zigzag_anchor vertical_anchor);
 

--- a/zigzag/src/cairo_util.c
+++ b/zigzag/src/cairo_util.c
@@ -4,6 +4,8 @@
 #include <wlr/render/wlr_renderer.h>
 #include <zen-common.h>
 
+#include "zigzag.h"
+
 struct wlr_texture *
 zigzag_wlr_texture_from_cairo_surface(
     cairo_surface_t *surface, struct wlr_renderer *renderer)
@@ -17,36 +19,43 @@ zigzag_wlr_texture_from_cairo_surface(
 }
 
 void
-zigzag_cairo_draw_centered_text(
-    cairo_t *cr, char *text, double width, double height)
+zigzag_cairo_draw_text(cairo_t *cr, char *text, double x, double y,
+    enum zigzag_anchor horizontal_anchor, enum zigzag_anchor vertical_anchor)
 {
   cairo_text_extents_t extents;
   cairo_text_extents(cr, text, &extents);
-  cairo_move_to(cr, width / 2 - (extents.width / 2 + extents.x_bearing),
-      height / 2 - (extents.height / 2 + extents.y_bearing));
-  cairo_show_text(cr, text);
-}
 
-void
-zigzag_cairo_draw_left_aligned_text(
-    cairo_t *cr, char *text, double width, double height, double padding)
-{
-  UNUSED(width);
-  cairo_text_extents_t extents;
-  cairo_text_extents(cr, text, &extents);
-  cairo_move_to(
-      cr, padding, height / 2 - (extents.height / 2 + extents.y_bearing));
-  cairo_show_text(cr, text);
-}
+  x -= extents.x_bearing;
 
-void
-zigzag_cairo_draw_right_aligned_text(
-    cairo_t *cr, char *text, double width, double height, double padding)
-{
-  cairo_text_extents_t extents;
-  cairo_text_extents(cr, text, &extents);
-  cairo_move_to(cr, width - (extents.width + extents.x_bearing + padding),
-      height / 2 - (extents.height / 2 + extents.y_bearing));
+  switch (horizontal_anchor) {
+    case ZIGZAG_ANCHOR_LEFT:
+      break;
+    case ZIGZAG_ANCHOR_CENTER:
+      x -= extents.width / 2;
+      break;
+    case ZIGZAG_ANCHOR_RIGHT:
+      x -= extents.width;
+      break;
+    default:
+      zn_error("invalid horizon anchor");
+      return;
+  }
+
+  switch (vertical_anchor) {
+    case ZIGZAG_ANCHOR_TOP:
+      y += extents.height;
+      break;
+    case ZIGZAG_ANCHOR_CENTER:
+      y += extents.height / 2;
+      break;
+    case ZIGZAG_ANCHOR_BOTTOM:
+      break;
+    default:
+      zn_error("invalid vertical anchor");
+      return;
+  }
+
+  cairo_move_to(cr, x, y);
   cairo_show_text(cr, text);
 }
 


### PR DESCRIPTION
## Context

Now there are three methods of drawing text in zigzag; `zigzag_cairo_draw_centered_text`, `zigzag_cairo_draw_left_aligned_text`, `zigzag_cairo_draw_right_aligned_text`. And they required the size of the container.

To draw the text more flexibly, it should use coordinate (x, y) and anchor (horizontal: left/center/right, vertical: top/center/bottom).

## Summary

Remove all of functions I mentioned above, add `zigzag_cairo_draw_text`

## How to check behavior

Check that the clock in the menubar is rendered at same position
